### PR TITLE
Make some speed ups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ To accumulate XML events in a list:
 
     xml_read.fold_content(list.cons, Stream, [], Result, !IO)
 
-Unlike expat and SAX, you don't register event handler functions. Every STag and ETag will be passed to the accumulator predicate. Textual data will only trigger an event if it is not whitespace-only. This behaviour is choosen to suppress whitespace that is only used to format/indent the XML.
+Unlike expat and SAX, you don't register event handler functions. Every STag and ETag will be passed to the accumulator predicate. Textual data will only trigger an event if it is not whitespace-only. This behaviour is chosen to suppress whitespace that is only used to format/indent the XML.
 
-If textual data is not whitepace-only, it will be passed to the accumulator predicate, ignoring leading whitespace.
+If textual data is not whitespace-only, it will be passed to the accumulator predicate, ignoring leading whitespace.
 
 You might accumulate XML events in a custom data structure directly or build a generic XML-DOM first and query it later.
 


### PR DESCRIPTION
Cumulatively, this results in ~25% speed up.

src/xml_read.m:
    Implement the suggestion to use read_char_unboxed in instead of read_char.
    This avoids a memory allocation along the commonly used path.

    Use string.from_rev_char_list/1 in order to avoid some list reverse operations.

README.md:
    Unrelated: fix a couple of typos.